### PR TITLE
Registering empty service worker to browser

### DIFF
--- a/css/rev-settings.css
+++ b/css/rev-settings.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Raleway:300,500,600,700,900,400);
+@import url(//fonts.googleapis.com/css?family=Raleway:300,500,600,700,900,400);
 
 html {
 overflow-x:hidden;

--- a/css/style.css
+++ b/css/style.css
@@ -37,9 +37,9 @@
 
 /* ================================================== */
 @charset "utf-8";
-@import url(http://fonts.googleapis.com/css?family=Raleway:300,500,600,700,900,400);
-@import url(http://fonts.googleapis.com/css?family=Cabin:400,400italic,500,500italic,600,600italic,700,700italic);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,300,300italic,600,600italic,700,700italic);
+@import url(//fonts.googleapis.com/css?family=Raleway:300,500,600,700,900,400);
+@import url(//fonts.googleapis.com/css?family=Cabin:400,400italic,500,500italic,600,600italic,700,700italic);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,400italic,300,300italic,600,600italic,700,700italic);
 
 /* ================================================== */
 /* body */

--- a/index.html
+++ b/index.html
@@ -1133,6 +1133,7 @@
     <script src="js/validation.js"></script>
     <script src="js/jquery.stellar.min.js"></script>
     <script src="js/designesia.js"></script>
+    <script src="js/addServiceWorker.js"></script>
 
     <!-- SLIDER REVOLUTION SCRIPTS  -->
     <script type="text/javascript" src="rs-plugin/js/jquery.themepunch.plugins.min.js"></script>

--- a/js/addServiceWorker.js
+++ b/js/addServiceWorker.js
@@ -1,0 +1,13 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+        navigator.serviceWorker.register('service-worker.js')
+            .then(function(registration) {
+                // Registration was successful
+                console.log('ServiceWorker registration successful ' 
+                + 'with scope: ', registration.scope);
+            }, function(err) {
+                // registration failed
+                console.log('ServiceWorker registration failed: ', err);
+            });
+    });
+}


### PR DESCRIPTION
This is with reference to issue #19. This adds a new empty service worker. The service worker is in the root directory so it has access to any css files which might might to be cached. If the service worker is placed in /js/, the scope can not be changed to root easily.
This change also changes the paths of a few fonts to relative so that the website works properly on browsers which block mixed active contents such as Firefox (requesting acccess of content in HTTP pages from HTTPS page).  